### PR TITLE
add tf-idf to para & fix get_threshold param issue

### DIFF
--- a/demo_hdfs/PCA_hdfs.py
+++ b/demo_hdfs/PCA_hdfs.py
@@ -9,13 +9,14 @@ para = {
 'path':'../../Data/SOSP_data/', # directory for input data
 'log_seq_file_name':'rm_repeat_rawTFVector.txt', # filename for log sequence data file
 'label_file_name':'rm_repeat_mlabel.txt', # filename for label data file
-'fraction':0.95
+'fraction':0.95,
+'tf-idf': True
 }
 
 
 if __name__ == '__main__':
 	raw_data, label_data = data_loader.hdfs_data_loader(para)
-	weigh_data = PCA.weighting(raw_data)
+	weigh_data = PCA.weighting(para, raw_data)
 	threshold, C = PCA.get_threshold(para, weigh_data)
 	PCA.anomaly_detection(weigh_data, label_data, C, threshold)
 


### PR DESCRIPTION
if tf-idf is not in para key, then the error would happen, and the evaluation is not really good. So I'm add tf-idf back, everything looks great.