### PR TITLE
needed wheel to build sklearn in a venv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+wheel
 sklearn
 pandas


### PR DESCRIPTION
Complete output from command /mnt/d/pythonprojects/loglizer/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-g0d1hjns/sklearn/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpda1yffvjpip-wheel- --python-tag cp36:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help

  error: invalid command 'bdist_wheel'

  ----------------------------------------
  Failed building wheel for sklearn