### PR TITLE
InvariantsMiner Optimisation

### DIFF
--- a/loglizer/dataloader.py
+++ b/loglizer/dataloader.py
@@ -68,7 +68,7 @@ def load_HDFS(log_file, label_file=None, window='session', train_ratio=0.5, spli
 
     if log_file.endswith('.npz'):
         # Split training and validation set in a class-uniform way
-        data = np.load(log_file)
+        data = np.load(log_file, allow_pickle=True)
         x_data = data['x_data']
         y_data = data['y_data']
         (x_train, y_train), (x_test, y_test) = _split_data(x_data, y_data, train_ratio, split_type)

--- a/loglizer/models/InvariantsMiner.py
+++ b/loglizer/models/InvariantsMiner.py
@@ -262,17 +262,17 @@ class InvariantsMiner(object):
         """
 
         set_len = len(item_list)
-        return_list = []
+        return_set = set()
         for i in range(set_len):
             for j in range(i + 1, set_len):
                 i_set = set(item_list[i])
                 j_set = set(item_list[j])
-                if len(i_set.union(j_set)) == length:
-                    joined = sorted(list(i_set.union(j_set)))
-                    if joined not in return_list:
-                        return_list.append(joined)
-        return_list = sorted(return_list)
-        return return_list
+                u = i_set.union(j_set)
+                if len(u) == length:
+                    joined = tuple(sorted(list(u)))
+                    return_set.add(joined)
+        return_set = sorted(return_set)
+        return return_set
 
 
     def _check_candi_valid(self, item, length, search_space):


### PR DESCRIPTION
For datasets with a large number of log keys, InvariantsMiner has been exceptionally slow.
I performed tests with a linux syslog dataset (415 log keys) and fitting times have been unbearable.

I profiled InvariantsMiner and detected that the (by far) largest amount of time is spent in the method `_join_set`. I optimised this method in order to reduce its computational complexity. 

Now, runtimes are considerably better for linux syslogs.
For HDFS logs, runtimes didn't change.

